### PR TITLE
fix: rotation calculation to align FFmpeg and WebCodecs, output to VideoDecoder config

### DIFF
--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -22,8 +22,13 @@ export const MEDIA_TYPE_TO_AVMEDIA_TYPE = {
   [SUBTITLE]: AVMediaType.AVMEDIA_TYPE_SUBTITLE
 } as const;
 
+// Extended VideoDecoderConfig to include rotation property
+export interface ExtendedVideoDecoderConfig extends VideoDecoderConfig {
+  rotation?: number;
+}
+
 export type MediaTypeToConfig = {
-  [VIDEO]: VideoDecoderConfig;
+  [VIDEO]: ExtendedVideoDecoderConfig;
   [AUDIO]: AudioDecoderConfig;
 }
 

--- a/src/web-demuxer.ts
+++ b/src/web-demuxer.ts
@@ -355,7 +355,7 @@ export class WebDemuxer {
    * Generate decoder config for video or audio
    * @param type The type of media ('video' or 'audio')
    * @param avStream WebAVStream
-   * @returns VideoDecoderConfig | AudioDecoderConfig
+   * @returns ExtendedVideoDecoderConfig | AudioDecoderConfig
    */
   public genDecoderConfig<T extends WebCodecsSupportedMediaType>(
     type: T,
@@ -367,6 +367,7 @@ export class WebDemuxer {
         codedWidth: avStream.width,
         codedHeight: avStream.height,
         description: avStream.extradata?.length > 0 ? avStream.extradata : undefined,
+        rotation: avStream.rotation,
       } as MediaTypeToConfig[T];
     } else {
       return {
@@ -403,7 +404,7 @@ export class WebDemuxer {
   /**
    * Get decoder config for WebCodecs
    * @param type The type of media ('video' or 'audio')
-   * @returns Promise<VideoDecoderConfig | AudioDecoderConfig>
+   * @returns Promise<ExtendedVideoDecoderConfig | AudioDecoderConfig>
    */
   public getDecoderConfig<T extends WebCodecsSupportedMediaType>(type: T): Promise<MediaTypeToConfig[T]> {
     return this.getMediaStream(type).then(stream => this.genDecoderConfig(type, stream));


### PR DESCRIPTION
VideoDecoder optionally supports rotation options on most browsers, but expects a clockwise angle from 0-360.

This branch:
* Changes rotation extraction function from counterclockwise rotation to clockwise (also maps negative degrees to positive ones),
* Changes rotation extraction function to prioritize metadata rotation tag if available,
* Exposes rotation tag via `genDecoderConfig` to use in VideoDecoder